### PR TITLE
Validate address format early

### DIFF
--- a/batch_slot_diff.py
+++ b/batch_slot_diff.py
@@ -53,6 +53,7 @@ def main():
     for row in reader:
         try:
             address = checksum(row["address"].strip())
+            if not Web3.is_address(address): print(f"❌ Invalid address: {row['address']}"); continue
             slot = parse_slot(row["slot"].strip())
             block_a = int(row["block_a"])
             block_b = int(row["block_b"])


### PR DESCRIPTION
Prevents runtime crashes if an invalid address sneaks into the input file.