### PR TITLE
Report zero-value slots

### DIFF
--- a/batch_slot_diff.py
+++ b/batch_slot_diff.py
@@ -79,6 +79,7 @@ def main():
         leaf_b = leaf_commitment(chain_id, address, slot, block_b, v_b)
         root = pair_root(leaf_a, leaf_b)
         changed = "YES" if v_a != v_b else "NO"
+        if v_a == v_b == b"\x00" * 32: print(f"ℹ️  Slot {slot} for {address} is zero at both blocks.")
 
         writer.writerow({
             "address": address,


### PR DESCRIPTION
82 line - warns when the user comparing an empty or uninitialized storage slot