### PR TITLE
Detect very short block range

### DIFF
--- a/slot_change_finder.py
+++ b/slot_change_finder.py
@@ -93,6 +93,7 @@ def main():
     if lo > hi:
         lo, hi = hi, lo
         print("🔄 Swapped block order for ascending search.")
+    if hi - lo < 2: print("⚠️ Block range too small — binary search may not detect changes accurately.")
 
     w3 = connect(args.rpc)
     chain_id = w3.eth.chain_id


### PR DESCRIPTION
Alerts the user that they’re scanning too narrow of a block window