### PR TITLE
Normalize storage length to 32 bytes

### DIFF
--- a/slot_change_finder.py
+++ b/slot_change_finder.py
@@ -114,6 +114,7 @@ def main():
 
     base_val = storage_at(str(w3.provider.endpoint_uri), address, slot, lo)
     end_val  = storage_at(str(w3.provider.endpoint_uri), address, slot, hi)
+    if len(base_val) != 32 or len(end_val) != 32: print("❌ Storage read not 32 bytes."); sys.exit(2)
 
     print("\n📦 Target")
     print(f"  Address: {address}")


### PR DESCRIPTION
Storage words are 32 bytes; anything else signals a provider/client quirk you should halt on