### PR TITLE
Early exit on identical bounds

### DIFF
--- a/slot_change_finder.py
+++ b/slot_change_finder.py
@@ -93,7 +93,8 @@ def main():
     if lo > hi:
         lo, hi = hi, lo
         print("🔄 Swapped block order for ascending search.")
-
+        if lo == hi: print("ℹ️ start_block == end_block; nothing to search."); sys.exit(0)
+            
     w3 = connect(args.rpc)
     chain_id = w3.eth.chain_id
     tip = w3.eth.block_number


### PR DESCRIPTION
Saves RPC calls and avoids misleading “no change” messaging when the range is empty