### PR TITLE
Abort if binary search encounters inconsistent read (reorg/race)

### DIFF
--- a/slot_change_finder.py
+++ b/slot_change_finder.py
@@ -69,6 +69,7 @@ def find_first_change(w3: Web3, addr: str, slot: int, lo: int, hi: int) -> int |
     while right - left > 1:
         mid = (left + right) // 2
         vmid = storage_at(str(w3.provider.endpoint_uri), addr, slot, mid)
+        if mid in (lo, hi): print("❌ Inconsistent boundary read; possible reorg."); sys.exit(2)
         if vmid == base:
             left = mid
         else:


### PR DESCRIPTION
If a mid read equals a boundary unexpectedly due to reorgs/caching quirks, bail with a clear error rather than looping or returning a wrong boundary