### PR TITLE
Catch invalid start block

### DIFF
--- a/slot_change_stream.py
+++ b/slot_change_stream.py
@@ -81,6 +81,7 @@ def stream(args):
 
     # Start from either user-specified block or tip
     current = args.start if args.start is not None else w3.eth.block_number
+    if current < 0: print("❌ start block cannot be negative."); sys.exit(2)
 
     while not stop_flag["stop"]:
         try:


### PR DESCRIPTION
It prevents invalid negative block numbers that would crash later calls