### PR TITLE
Validate the raw address before checksum

### DIFF
--- a/slot_change_stream.py
+++ b/slot_change_stream.py
@@ -50,6 +50,7 @@ def unix_to_utc(ts: int) -> str:
 
 def stream(args):
     w3 = connect(args.rpc)
+    if not Web3.is_address(args.address): print("❌ Invalid Ethereum address."); sys.exit(2)
     address = checksum(args.address)
     slot = parse_slot(args.slot)
 


### PR DESCRIPTION
It prevents wasting RPC calls on garbage input and confusing “not found” errors later