### PR TITLE
Check if user forgot to set RPC URL

### DIFF
--- a/slot_diff_attest.py
+++ b/slot_diff_attest.py
@@ -95,7 +95,8 @@ def main():
     if block_a > block_b:
         block_a, block_b = block_b, block_a
         print("🔄 Swapped block order for ascending comparison.")
-
+        
+    if "your_api_key" in args.rpc: print("⚠️ Reminder: replace Infura placeholder with a real RPC key.")
     w3 = connect(args.rpc)
     chain_id = w3.eth.chain_id
     tip = w3.eth.block_number


### PR DESCRIPTION
Many users forget to replace the default Infura key. This avoids confusing “connection refused” errors.