### PR TITLE
Warn if RPC URL still has the Infura placeholder

### DIFF
--- a/slot_diff_attest.py
+++ b/slot_diff_attest.py
@@ -95,7 +95,8 @@ def main():
     if block_a > block_b:
         block_a, block_b = block_b, block_a
         print("🔄 Swapped block order for ascending comparison.")
-
+        
+    if "your_api_key" in args.rpc: print("⚠️ RPC_URL still uses Infura placeholder — replace with a real key.")
     w3 = connect(args.rpc)
     chain_id = w3.eth.chain_id
     tip = w3.eth.block_number


### PR DESCRIPTION
Prevents confusing “connection refused/unauthorized” errors from a forgotten placeholder