### PR TITLE
Added human-readable timestamps for the compared blocks

### DIFF
--- a/slot_diff_attest.py
+++ b/slot_diff_attest.py
@@ -109,6 +109,7 @@ def main():
     try:
         v_a = w3.eth.get_storage_at(address, slot, block_identifier=block_a)
         v_b = w3.eth.get_storage_at(address, slot, block_identifier=block_b)
+        ba = w3.eth.get_block(block_a); bb = w3.eth.get_block(block_b); print(f"🕒 A:{time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(ba.timestamp))}  B:{time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(bb.timestamp))} UTC")
     except Exception as e:
         print(f"❌ Storage read failed: {e}"); sys.exit(2)
 


### PR DESCRIPTION
It gives clear context when the two observations happened on-chain (great for logs/audits).