### PR TITLE
Placeholder RPC key → silent auth failures

### DIFF
--- a/slot_diff_attest.py
+++ b/slot_diff_attest.py
@@ -96,6 +96,8 @@ def main():
         block_a, block_b = block_b, block_a
         print("🔄 Swapped block order for ascending comparison.")
 
+
+if "your_api_key" in args.rpc: print("⚠️ RPC_URL still uses an Infura placeholder — replace it.")
     w3 = connect(args.rpc)
     chain_id = w3.eth.chain_id
     tip = w3.eth.block_number


### PR DESCRIPTION
Users might forget to replace the Infura placeholder