### PR TITLE
Reversed block bounds

### DIFF
--- a/slot_diff_attest.py
+++ b/slot_diff_attest.py
@@ -89,7 +89,8 @@ def main():
     address = checksum(args.address)
     slot = parse_slot(args.slot)
     block_a, block_b = args.block_a, args.block_b
-
+    if block_a > block_b: block_a, block_b = block_b, block_a; print("🔄 Swapped block order for ascending comparison.")
+        
     if min(block_a, block_b) < 0:
         print("❌ Block numbers must be ≥ 0."); sys.exit(2)
     if block_a > block_b:


### PR DESCRIPTION
block_a > block_b leads to confusing logs