### PR TITLE
Address validation before proceeding

### DIFF
--- a/slot_change_stream.py
+++ b/slot_change_stream.py
@@ -50,6 +50,7 @@ def unix_to_utc(ts: int) -> str:
 
 def stream(args):
     w3 = connect(args.rpc)
+    if not Web3.is_address(args.address): print("❌ Invalid address format."); sys.exit(2)
     address = checksum(args.address)
     slot = parse_slot(args.slot)
 


### PR DESCRIPTION
It ensures the input address is syntactically valid and avoids confusing downstream errors when trying to fetch code or storage.