### PR TITLE
Clamp the start block to the current tip

### DIFF
--- a/slot_change_stream.py
+++ b/slot_change_stream.py
@@ -78,6 +78,7 @@ def stream(args):
     last_ue = None
     last_leaf  = None
     changes = 0
+   if args.start is not None and args.start > tip: print(f"⚠️ start block {args.start} > tip {tip}; using tip instead."); current = tip
 
     # Start from either user-specified block or tip
     current = args.start if args.start is not None else w3.eth.block_number


### PR DESCRIPTION
that avoids starting the monitoring from a block that doesn’t exist yet, which would cause immediate failures or blank reads.