### PR TITLE
Warn when target has no contract code

### DIFF
--- a/batch_slot_diff.py
+++ b/batch_slot_diff.py
@@ -65,8 +65,7 @@ def main():
             block_a, block_b = block_b, block_a
 
         code = w3.eth.get_code(address)
-        if not code:
-            print(f"⚠️  {address} has no contract code; continuing.", file=sys.stderr)
+        if not code: print("⚠️ Target address has no contract code (likely EOA) — storage slot results may be misleading.")
 
         try:
             v_a = w3.eth.get_storage_at(address, slot, block_identifier=block_a)


### PR DESCRIPTION
cause EOAs don’t have smart-contract storage. This helps avoid mis-interpreting zero values as meaningful slot changes when in fact you’re watching an account with no slots