### PR TITLE
Light pacing to reduce throttling on long scans

### DIFF
--- a/slot_layout_probe.py
+++ b/slot_layout_probe.py
@@ -167,6 +167,7 @@ def main():
         # light progress pulse
         if i % 64 == 0:
             print(f"… {i}/{len(slots)} slots scanned")
+        if i % 256 == 0: time.sleep(0.1)
 
     # Output
     header = ["address","chain_id","slot_dec","block_a","block_b","value_a","value_b","leaf_a","leaf_b","pair_root","changed"]


### PR DESCRIPTION
A tiny breather every 256 slots prevents hammering public RPCs during big ranges