### PR TITLE
Clamp huge slot ranges more safely

### DIFF
--- a/slot_layout_probe.py
+++ b/slot_layout_probe.py
@@ -39,10 +39,14 @@ def parse_slots_arg(arg: str) -> List[int]:
             a_i, b_i = parse_slot(a), parse_slot(b)
             if a_i > b_i:
                 a_i, b_i = b_i, a_i
-            # guard large ranges by default
+                     # guard large ranges by default
             if b_i - a_i > 5000:
-                print(f"⚠️  Truncating large range {a_i}-{b_i} to 5000 slots.")
+                print(
+                    f"⚠️  Truncating large range {a_i}-{b_i} to 5000 slots.",
+                    file=sys.stderr,
+                )
                 b_i = a_i + 5000
+
             slots.extend(range(a_i, b_i + 1))
         else:
             slots.append(parse_slot(chunk))


### PR DESCRIPTION
Don’t silently truncate more than 5000 slots; keep user informed.