### PR TITLE
Use time.monotonic consistently

### DIFF
--- a/slot_layout_probe.py
+++ b/slot_layout_probe.py
@@ -132,6 +132,7 @@ def main():
 
     slots = list(iter_slots(args))
     print(f"🔎 Scanning {len(slots)} slots from {hex(min(slots)) if slots else 'N/A'} to {hex(max(slots)) if slots else 'N/A'}")
+        # use monotonic clock for elapsed-time measurement
     t0 = time.monotonic()
 
     rows: List[Tuple] = []


### PR DESCRIPTION
Better for measuring elapsed durations than time.time()