### PR TITLE
Safe pair_root ordering with explicit hex compare

### DIFF
--- a/slot_layout_probe.py
+++ b/slot_layout_probe.py
@@ -73,7 +73,7 @@ def leaf_commitment(chain_id: int, address: str, slot: int, block_number: int, v
     return Web3.keccak(payload)
 
 def pair_root(a: bytes, b: bytes) -> str:
-    x, y = (a, b) if a < b else (b, a)
+     x, y = (a, b) if a.hex() < b.hex() else (b, a)
     return "0x" + Web3.keccak(x + y).hex()
 
 def to_hex(b: bytes) -> str:


### PR DESCRIPTION
Be explicit about sort semantics on bytes.