### PR TITLE
Exit non-zero if no rows emitted

### DIFF
--- a/slot_layout_probe.py
+++ b/slot_layout_probe.py
@@ -167,6 +167,8 @@ def main():
         # light progress pulse
         if i % 64 == 0:
             print(f"… {i}/{len(slots)} slots scanned")
+    if not rows:
+        print("⚠️  No rows to emit (filters removed all slots or all zero).", file=sys.stderr)
 
     # Output
     header = ["address","chain_id","slot_dec","block_a","block_b","value_a","value_b","leaf_a","leaf_b","pair_root","changed"]


### PR DESCRIPTION
If filters result in zero rows, reflect that for callers.