### PR TITLE
Check chain ID is consistent during run

### DIFF
--- a/slot_layout_probe.py
+++ b/slot_layout_probe.py
@@ -113,6 +113,14 @@ def main():
 
     w3 = connect(args.rpc)
     chain_id = w3.eth.chain_id
+            current_chain = w3.eth.chain_id
+        if current_chain != chain_id:
+            print(
+                f"⚠️  Chain ID changed during probe: {chain_id} → {current_chain}",
+                file=sys.stderr,
+            )
+            chain_id = current_chain
+
     tip = w3.eth.block_number
     print(f"🌐 Connected: chainId={chain_id}, tip={tip}")
 


### PR DESCRIPTION
If RPC returns different chainId mid-run (reorg or misconfig), warn.