### PR TITLE
Log diagnostics to stderr

### DIFF
--- a/slot_diff_attest.py
+++ b/slot_diff_attest.py
@@ -36,7 +36,7 @@ class Attestation:
 
 def checksum(addr: str) -> str:
     if not Web3.is_address(addr):
-        print("❌ Invalid Ethereum address."); sys.exit(2)
+        print("❌ Invalid Ethereum address.", file=sys.stderr); sys.exit(2)
     return Web3.to_checksum_address(addr)
 
 def parse_slot(s: str) -> int:


### PR DESCRIPTION
Keep stdout clean for programmatic use; logs / errors should go to stderr.