### PR TITLE
Configurable RPC timeout (env)

### DIFF
--- a/slot_diff_attest.py
+++ b/slot_diff_attest.py
@@ -12,7 +12,9 @@ except Exception:
     Account = None  # signing remains optional
 
 RPC_URL = os.getenv("RPC_URL", "https://mainnet.infura.io/v3/your_api_key")
+RPC_TIMEOUT = float(os.getenv("RPC_TIMEOUT", "20"))
 DEFAULT_OUT = "slot_diff_attestation.json"
+
 
 @dataclass
 class Attestation:
@@ -49,7 +51,7 @@ def parse_slot(s: str) -> int:
     return v
 
 def connect(url: str) -> Web3:
-    w3 = Web3(Web3.HTTPProvider(url, request_kwargs={"timeout": 20}))
+       w3 = Web3(Web3.HTTPProvider(url, request_kwargs={"timeout": RPC_TIMEOUT}))
     if not w3.is_connected():
         print("❌ Failed to connect to RPC."); sys.exit(1)
     return w3


### PR DESCRIPTION
Avoid hard-coding 20 seconds; allow override via env