### PR TITLE
Handle equal block numbers explicitly

### DIFF
--- a/slot_diff_attest.py
+++ b/slot_diff_attest.py
@@ -91,10 +91,16 @@ def main():
     block_a, block_b = args.block_a, args.block_b
 
     if min(block_a, block_b) < 0:
-        print("❌ Block numbers must be ≥ 0."); sys.exit(2)
+        print("❌ Block numbers must be ≥ 0.", file=sys.stderr); sys.exit(2)
+    if block_a == block_b:
+        print(
+            "ℹ️  block_a == block_b; attestation compares the same block twice.",
+            file=sys.stderr,
+        )
     if block_a > block_b:
         block_a, block_b = block_b, block_a
-        print("🔄 Swapped block order for ascending comparison.")
+        print("🔄 Swapped block order for ascending comparison.", file=sys.stderr)
+
 
     w3 = connect(args.rpc)
     chain_id = w3.eth.chain_id


### PR DESCRIPTION
If block_a == block_b, make it explicit that “changed” will always be false