### PR TITLE
Fix inconsistent variable names: last_ue / last_value

### DIFF
--- a/slot_change_stream.py
+++ b/slot_change_stream.py
@@ -74,9 +74,9 @@ def stream(args):
         if args.csv_header:
             csv_writer.writeheader()
 
-    last_block = None
-    last_ue = None
-    last_leaf  = None
+     last_block = None
+    last_value = None
+    last_leaf = None
     changes = 0
 
     # Start from either user-specified block or tip


### PR DESCRIPTION
You declare last_ue but then use last_value. This crashes on first access.