### PR TITLE
--exit-on-error behavior

### DIFF
--- a/slot_change_stream.py
+++ b/slot_change_stream.py
@@ -97,7 +97,12 @@ def stream(args):
             except Exception as e:
         time.sleep(0.3)
         try: blk = w3.eth.get_block(current); val = get_storage_at(w3, address, slot, current)
-        except Exception as e2: print(f"⚠️ Block {current} fetch error (after retry): {e2}"); break
+                       except Exception as e2:
+                    print(f"⚠️ Block {current} fetch error (after retry): {e2}", file=sys.stderr)
+                    if args.exit_on_error:
+                        stop_flag["stop"] = True
+                    break
+
 
 
             leaf = leaf_commitment(chain_id, address, slot, current, val)
@@ -167,6 +172,11 @@ def stream(args):
 def main():
     ap = argparse.ArgumentParser(description="Live monitor a storage slot and emit commitment roots on change.")
     ap.add_argument("address", help="Contract address (0x...)")
+        ap.add_argument(
+        "--exit-on-error",
+        action="store_true",
+        help="Exit immediately on block fetch errors instead of continuing",
+    )
     ap.add_argument("slot", help="Storage slot (decimal or 0xHEX)")
     ap.add_argument("--rpc", default=RPC_URL, help="RPC URL (default from RPC_URL env)")
     ap.add_argument("--start", type=int, help="Start block (default: current tip)")


### PR DESCRIPTION
Currently, some errors (like fetch retry failure) cause a break in inner loop but not necessarily process exit. Add option to exit entirely.