### PR TITLE
Remove stray b/slot_layout_probe.py line

### DIFF
--- a/slot_layout_probe.py
+++ b/slot_layout_probe.py
@@ -2,7 +2,6 @@
 Importing this module has no side effects.
 """
 # slot_layout_probe.py
-b/slot_layout_probe.py
 # Probe a contract's storage layout: scan a set/range of slots at two blocks,
 # report non-zero values and changes, and emit commitments + pair roots (CSV/STDOUT).
 import logging


### PR DESCRIPTION
That line (b/slot_layout_probe.py) is invalid Python and will break the module