### PR TITLE
Fix pair_root() indentation

### DIFF
--- a/slot_layout_probe.py
+++ b/slot_layout_probe.py
@@ -96,7 +96,7 @@ def leaf_commitment(chain_id: int, address: str, slot: int, block_number: int, v
     return Web3.keccak(payload)
 
 def pair_root(a: bytes, b: bytes) -> str:
-     x, y = (a, b) if a.hex() < b.hex() else (b, a)
+    x, y = (a, b) if a.hex() < b.hex() else (b, a)
     return "0x" + Web3.keccak(x + y).hex()
 
 def to_hex(b: bytes, prefix: bool = True) -> str:


### PR DESCRIPTION
Indentation is off, which can cause syntax errors