### PR TITLE
Make “blocks beyond tip” clamp readable and multi-line

### DIFF
--- a/slot_layout_probe.py
+++ b/slot_layout_probe.py
@@ -168,8 +168,11 @@ def main() -> None:
             )
             chain_id = current_chain
 
-    tip = w3.eth.block_number
-    if block_a > tip or block_b > tip: print(f"⚠️ Adjusting blocks beyond tip {tip}."); block_a = min(block_a, tip); block_b = min(block_b, tip)
+       tip = w3.eth.block_number
+    if block_a > tip or block_b > tip:
+        print(f"⚠️ Adjusting blocks beyond tip {tip}.", file=sys.stderr)
+        block_a = min(block_a, tip)
+        block_b = min(block_b, tip)
     print(f"🌐 Connected: chainId={chain_id}, tip={tip}")
 
     if block_b > tip:


### PR DESCRIPTION
Multiple statements on one line are hard to read and error-prone