### PR TITLE
Use time.monotonic() consistently for elapsed time

### DIFF
--- a/slot_layout_probe.py
+++ b/slot_layout_probe.py
@@ -195,8 +195,11 @@ def main() -> None:
         )
         sys.exit(2)
 
-    print(f"🔎 Scanning {len(slots)} slots from {hex(min(slots)) if slots else 'N/A'} to {hex(max(slots)) if slots else 'N/A'}")
-        # use monotonic clock for elapsed-time measurement
+       print(
+        f"🔎 Scanning {len(slots)} slots from "
+        f"{hex(min(slots)) if slots else 'N/A'} to {hex(max(slots)) if slots else 'N/A'}"
+    )
+    # use monotonic clock for elapsed-time measurement
     t0 = time.monotonic()
 
     rows: List[Tuple] = []


### PR DESCRIPTION
You already use it; ensure the initial t0 uses it too.