### PR TITLE
Move “both zero” informational print behind flags and to stderr

### DIFF
--- a/slot_layout_probe.py
+++ b/slot_layout_probe.py
@@ -214,7 +214,9 @@ except Exception as e:
             continue
 
         changed = v_a != v_b
-        if v_a == v_b == b"\x00"*32: print(f"ℹ️ Slot {hex(slot)}: both zero — likely unused storage.")
+        if v_a == v_b == b"\x00" * 32 and not (args.only_changed or args.only_nonzero):
+            print(f"ℹ️ Slot {hex(slot)}: both zero — likely unused storage.", file=sys.stderr)
+
         any_nonzero = (v_a != b"\x00"*32) or (v_b != b"\x00"*32)
         if args.only_changed and not changed:
             continue


### PR DESCRIPTION
Right now it prints for every zero slot, which can be spammy and goes to stdout