### PR TITLE
Fix parse_slot indentation and send errors to stderr

### DIFF
--- a/slot_diff_attest.py
+++ b/slot_diff_attest.py
@@ -49,11 +49,12 @@ def checksum(addr: str) -> str:
 def parse_slot(s: str) -> int:
     try:
         v = int(s, 0)  # decimal or 0xHEX
-        except Exception:
+    except Exception:
         print(f"❌ Invalid slot format: {s!r} (use decimal or 0xHEX).", file=sys.stderr)
         sys.exit(2)
     if v < 0 or v >= 2**256:
-        print("❌ Slot out of range [0, 2^256)."); sys.exit(2)
+        print("❌ Slot out of range [0, 2^256).", file=sys.stderr)
+        sys.exit(2)
     return v
 
 def connect(url: str) -> Web3:


### PR DESCRIPTION
Right now the except is mis-indented and will cause a syntax error. Also error messages should go to stderr.