### PR TITLE
Print the “both zero” hint to stderr

### DIFF
--- a/slot_diff_attest.py
+++ b/slot_diff_attest.py
@@ -158,7 +158,8 @@ if "your_api_key" in args.rpc: print("⚠️ RPC_URL still uses an Infura placeh
     leaf_b = leaf_commitment(chain_id, address, slot, block_b, v_b)
     root  = pair_root(leaf_a, leaf_b)
     changed = v_a != v_b
-    if v_a == v_b == b"\x00"*32: print("ℹ️ Both values are zero — double-check the slot index for this contract.")
+    if v_a == v_b == b"\x00" * 32:
+        print("ℹ️ Both values are zero — double-check the slot index for this contract.", file=sys.stderr)
         
     att = Attestation(
         address=address,


### PR DESCRIPTION
better to keep structured output on stdout clean