### PR TITLE
Warn if eth_account is missing only when --sign is requested

### DIFF
--- a/slot_diff_attest.py
+++ b/slot_diff_attest.py
@@ -14,7 +14,7 @@ try:
     from eth_account import Account
     from eth_account.messages import encode_defunct
 except Exception:
-    Account = None  # signing remains optional
+    Account = None   # eth_account is optional; signing will be disabled if not installed
 
 RPC_URL = os.getenv("RPC_URL", "https://mainnet.infura.io/v3/your_api_key")
 RPC_TIMEOUT = float(os.getenv("RPC_TIMEOUT", "20"))


### PR DESCRIPTION
Currently, the import failure is handled, but the message is only printed when --sign is used. That's already the behavior, but we can make the warning more explicit.