### PR TITLE
Fix parse_slot() indentation and send errors to stderr

### DIFF
--- a/slot_change_stream.py
+++ b/slot_change_stream.py
@@ -17,9 +17,11 @@ def parse_slot(s: str) -> int:
     try:
         v = int(s, 0)  # accepts decimal or hex like 0x5
     except Exception:
-              print("❌ Invalid slot format (use decimal or 0xHEX)."); sys.exit(2)
+        print("❌ Invalid slot format (use decimal or 0xHEX).", file=sys.stderr)
+        sys.exit(2)
     if v < 0 or v >= 2**256:
-        print("❌ Slot out of range [0, 2^256)."); sys.exit(2)
+        print("❌ Slot out of range [0, 2^256).", file=sys.stderr)
+        sys.exit(2)
     return v
 
 def connect(url: str) -> Web3:


### PR DESCRIPTION
The except block is mis-indented and the error goes to stdout