### PR TITLE
Fix typo: args.inter → args.interval

### DIFF
--- a/slot_change_stream.py
+++ b/slot_change_stream.py
@@ -65,7 +65,7 @@ def stream(args):
     chain_id = w3.eth.chain_id
     tip = w3.eth.block_number
     print(f"🌐 Connected to chainId {chain_id}, tip {tip}")
-    print(f"🔍 Watching address={address}, slot={hex(slot)} ({slot}) every {args.inter:.1f}s")
+    print(f"🔍 Watching address={address}, slot={hex(slot)} ({slot}) every {args.interval:.1f}s")
 
     stop_flag = {"stop": False}
     signal.signal(signal.SIGINT, lambda *_: (print("\n🛑 Interrupted."), stop_flag.update(stop=True)))


### PR DESCRIPTION
This will crash with AttributeError because there is no inter attribute