### PR TITLE
Define CSV fieldnames instead of [...] placeholder

### DIFF
--- a/slot_change_stream.py
+++ b/slot_change_stream.py
@@ -71,11 +71,26 @@ def stream(args):
     signal.signal(signal.SIGINT, lambda *_: (print("\n🛑 Interrupted."), stop_flag.update(stop=True)))
     signal.signal(signal.SIGTERM, lambda *_: (print("\n🛑 Terminated."), stop_flag.update(stop=True)))
 
-    csv_writer: Optional[csv.DictWriter] = None
-     if args.csv:
+        csv_writer: Optional[csv.DictWriter] = None
+    out_file = None
+    if args.csv:
         file_exists = os.path.exists(args.csv) and os.path.getsize(args.csv) > 0
         out_file = open(args.csv, "a", newline="")
-        csv_writer = csv.DictWriter(out_file, fieldnames=[...])
+        csv_writer = csv.DictWriter(
+            out_file,
+            fieldnames=[
+                "ts_utc",
+                "block",
+                "value",
+                "leaf",
+                "prev_block",
+                "prev_value",
+                "prev_leaf",
+                "pair_root",
+                "changed",
+            ],
+        )
+
         if args.csv_header and not file_exists:
             csv_writer.writeheader()
 


### PR DESCRIPTION
fieldnames=[...] is invalid and will raise an error. Use real names matching your writer rows