### PR TITLE
Use monotonic sleep properly between polling rounds

### DIFF
--- a/slot_change_stream.py
+++ b/slot_change_stream.py
@@ -176,11 +176,13 @@ def stream(args):
 
             current += 1
 
-        if stop_flag["stop"]:
+               if stop_flag["stop"]:
             break
-            t0 = time.monotonic(); 
-            while time.monotonic() - t0 < args.interval and not stop_flag["stop"]: time.sleep(0.05)
-        time.sleep(args.interval)
+
+        # Sleep until next polling tick, but allow quick interrupt
+        t0 = time.monotonic()
+        while time.monotonic() - t0 < args.interval and not stop_flag["stop"]:
+            time.sleep(0.05)
 
     if csv_writer:
         try:


### PR DESCRIPTION
a broken t0 = time.monotonic() block indented under the wrong branch