### PR TITLE
Ensure max_changes check handles 0 as “no limit”

### DIFF
--- a/slot_change_stream.py
+++ b/slot_change_stream.py
@@ -151,7 +151,7 @@ def stream(args):
                             "changed": "YES"
                         })
                     last_block, last_value, last_leaf = current, val, leaf
-                    if args.max_changes and changes >= args.max_changes:
+                                      if args.max_changes and changes >= args.max_changes:
                         print(f"✅ Max changes reached ({changes}); exiting.")
                         stop_flag["stop"] = True
                         break


### PR DESCRIPTION
if args.max_changes and changes >= args.max_changes, which is correct — just call it out as intentional and keep it