### PR TITLE
Fix storage_at() indentation and retries, plus stderr on failure

### DIFF
--- a/slot_change_finder.py
+++ b/slot_change_finder.py
@@ -24,14 +24,18 @@ def connect(url: str) -> Web3:
 
 @lru_cache(maxsize=8192)
 def storage_at(w3_provider_uri: str, address: str, slot: int, block_number: int) -> bytes:
-    # cache key uses provider URI string via decorator arg; w3 constructed per call to avoid unhashable
+    """
+    Cached storage read with simple retry logic (3 attempts).
+    Cache key uses the provider URI string plus address/slot/block.
+    """
     w3 = Web3(Web3.HTTPProvider(w3_provider_uri, request_kwargs={"timeout": 30}))
     for _ in range(3):
-    try:
-        return w3.eth.get_storage_at(address, slot, block_identifier=block_number)
-    except Exception as e:
-        time.sleep(0.3)
-print(f"❌ RPC retries failed for block {block_number}."); sys.exit(2)
+        try:
+            return w3.eth.get_storage_at(address, slot, block_identifier=block_number)
+        except Exception:
+            time.sleep(0.3)
+    print(f"❌ RPC retries failed for block {block_number}.", file=sys.stderr)
+    sys.exit(2)
 
 
 def leaf_commitment(chain_id: int, address: str, slot: int, block_number: int, value: bytes) -> bytes:


### PR DESCRIPTION
The for loop and try/except are mis-indented now; on failure, the print should go to stderr