### PR TITLE
Guard against unexpected address length in leaf_commitment

### DIFF
--- a/slot_change_finder.py
+++ b/slot_change_finder.py
@@ -35,9 +35,14 @@ print(f"❌ RPC retries failed for block {block_number}."); sys.exit(2)
 
 
 def leaf_commitment(chain_id: int, address: str, slot: int, block_number: int, value: bytes) -> bytes:
+    addr_hex = address[2:]
+    if len(addr_hex) != 40:
+        print(f"❌ Unexpected address length for {address}", file=sys.stderr)
+        sys.exit(2)
+
     payload = (
         chain_id.to_bytes(8, "big")
-        + bytes.fromhex(address[2:])
+        + bytes.fromhex(addr_hex)
         + slot.to_bytes(32, "big")
         + block_number.to_bytes(8, "big")
         + value.rjust(32, b"\x00")


### PR DESCRIPTION
In case someone passes a malformed address string (even after checksum), fail clearly