### PR TITLE
Make pair_root() lexicographically consistent

### DIFF
--- a/slot_change_finder.py
+++ b/slot_change_finder.py
@@ -45,7 +45,7 @@ def leaf_commitment(chain_id: int, address: str, slot: int, block_number: int, v
     return Web3.keccak(payload)
 
 def pair_root(a: bytes, b: bytes) -> str:
-    x, y = (a, b) if a < b else (b, a)
+    x, y = (a, b) if a.hex() < b.hex() else (b, a)
     return "0x" + Web3.keccak(x + y).hex()
 
 def fmt_ts(ts: int) -> str:


### PR DESCRIPTION
hex-based ordering in other scripts; here it uses raw bytes (a < b)