### PR TITLE
Highlight potential reorg in a clearer error and use stderr

### DIFF
--- a/slot_change_finder.py
+++ b/slot_change_finder.py
@@ -75,8 +75,10 @@ def find_first_change(w3: Web3, addr: str, slot: int, lo: int, hi: int) -> int |
     max_iters = 512
     while right - left > 1 and (max_iters := max_iters - 1) > 0:
         mid = (left + right) // 2
-        vmid = storage_at(str(w3.provider.endpoint_uri), addr, slot, mid)
-        if mid in (lo, hi): print("❌ Inconsistent boundary read; possible reorg."); sys.exit(2)
+             vmid = storage_at(str(w3.provider.endpoint_uri), addr, slot, mid)
+        if mid in (lo, hi):
+            print("❌ Inconsistent boundary read; possible reorg or unstable RPC data.", file=sys.stderr)
+            sys.exit(2)
         if vmid == base:
             left = mid
         else:


### PR DESCRIPTION
The mid-boundary check error should be clearer and not on stdout