### PR TITLE
Fix lo > hi branch indentation and only exit when equal

### DIFF
--- a/slot_change_finder.py
+++ b/slot_change_finder.py
@@ -99,11 +99,13 @@ def main():
     if slot < 0 or slot >= 2**256:
         print("❌ Slot out of range [0, 2^256)."); sys.exit(2)
 
-    lo, hi = args.start_block, args.end_block
+        lo, hi = args.start_block, args.end_block
     if lo > hi:
         lo, hi = hi, lo
-        print("🔄 Swapped block order for ascending search.")
-        if lo == hi: print("ℹ️ start_block == end_block; nothing to search."); sys.exit(0)
+        print("🔄 Swapped block order for ascending search.", file=sys.stderr)
+    if lo == hi:
+        print("ℹ️ start_block == end_block; nothing to search.", file=sys.stderr)
+        sys.exit(0)
             
     w3 = connect(args.rpc)
     print(f"🔗 Using RPC endpoint: {args.rpc}")


### PR DESCRIPTION
The if lo == hi line is fine logically, but we can make it clearer and use stderr