### PR TITLE
Docs: update Files section to list all CLI tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,23 @@
 A tiny Web3 tool that checks the soundness of a specific contract storage slot across two block heights. It fetches the storage value at block A and block B, computes Keccak commitments (leaves) that bind (chainId, address, slot, blockNumber, value), and then produces a deterministic pair commitment (a Merkle-style root over the two leaves). This mirrors the commitment patterns used in ZK/rollup systems (e.g., Aztec-like designs) where small roots capture larger facts; verifiers can later request the corresponding leaves to validate statements about history or equality.
 
 ## Files
-- app.py — CLI tool to read a storage slot at two blocks and emit a pair commitment.
-- README.md — this document.
+
+Core tool:
+
+  * `app.py` — CLI tool to read a storage slot at two blocks and emit a pair commitment.
+
+Companion tools:
+
+  * `batch_slot_diff.py` — process many (address, slot, block_a, block_b) rows from CSV and emit commitments in batch.
+  * `slot_diff_attest.py` — create a JSON attestation for a single slot across two blocks, optionally signed with an EOA key.
+  * `slot_layout_probe.py` — probe a contract’s storage layout across ranges of slots and two blocks; emits CSV with values and pair roots.
+  * `slot_change_stream.py` — live monitor a single storage slot as new blocks arrive, printing changes and commitments (optionally logging to CSV).
+  * `slot_change_finder.py` — helper for searching the block range where a given slot first changes (if present).
+
+Docs:
+
+  * `README.md` — this document.
+
 
 ## Requirements
 - Python 3.10+


### PR DESCRIPTION
## Summary

The README's `## Files` section currently lists only:

- `app.py`
- `README.md`

However, the repository now also includes several additional CLI helpers:

- `batch_slot_diff.py`
- `slot_diff_attest.py`
- `slot_layout_probe.py`
- `slot_change_stream.py`
- `slot_change_finder.py`

This mismatch may confuse users browsing the repo or trying to discover available tools.

## Changes

- Update the `## Files` section in `README.md` to include all of the main Python entrypoints and a one-line explanation for each:
  - `app.py` – single-slot, two-block commitment checker (core tool).
  - `batch_slot_diff.py` – batch CSV processor for many slots/blocks.
  - `slot_diff_attest.py` – signed JSON attestation generator.
  - `slot_layout_probe.py` – scan ranges of slots and emit CSV/commitments.
  - `slot_change_stream.py` – live monitor for slot changes over new blocks.
  - `slot_change_finder.py` – helper to search for the first block where a slot value changed (if applicable).
- Keep `README.md` itself listed as the documentation file.

## Rationale

- Keeps documentation in sync with the actual repository contents.
- Makes the additional tools discoverable for users who only read the README.
- Helps people quickly pick the right script for their use case (single slot vs batch vs streaming vs layout probing).

## Notes

This is a docs-only change; no code behavior is modified.