### PR TITLE
Feature: add --json flag to app.py for machine-readable slot diff output

### DIFF
--- a/app.py
+++ b/app.py
@@ -101,6 +101,20 @@ def main():
     print(f"  Block B: {block_b}  Value: {to_hex(v_b)}  Leaf: {to_hex(leaf_b)}")
     print(f"\n🌳 Pair commitment (Merkle-style root over two leaves): {root}")
     print(f"🔁 Value changed between blocks: {changed}")
+if args.json:
+    import json
+    payload = {
+        "address": address,
+        "slot": slot,
+        "block_a": block_a,
+        "block_b": block_b,
+        "value_a": value_a,
+        "value_b": value_b,
+        "changed": (value_a != value_b),
+        "commitment_hex": pair_hex,
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return
 
     if v_a == v_b:
         print("✅ Soundness note: storage value is identical at both blocks; root binds the equality evidence.")


### PR DESCRIPTION
## Summary

`app.py` currently prints results in a human-readable format only.   For scripting, automation, CI pipelines, dashboards, or data ingestion, it would be extremely helpful to have a JSON output option.

This PR adds a `--json` flag so callers can request structured output describing:

- the slot value at block A  
- the slot value at block B  
- whether they differ  
- the pair commitment emitted  
- all arguments (address, slot, block numbers)

## Proposed Changes

- Add a `--json` boolean flag to `argparse`.
- After computing:
  - `value_a`
  - `value_b`
  - the hex commitment (`pair_hex`)
- If `--json` is set:
  - print a JSON object with keys:
    - `address`
    - `slot`
    - `block_a`
    - `block_b`
    - `value_a`
    - `value_b`
    - `changed` (bool)
    - `commitment_hex`
  - then exit without printing the human-readable summary.

## Example Output

```json
{
  "address": "0x1234...",
  "slot": "0x0",
  "block_a": 18000000,
  "block_b": 18000010,
  "value_a": "0x0000...",
  "value_b": "0x0000...",
  "changed": false,
  "commitment_hex": "0xabc123..."
}