### PR TITLE
Chore: validate `--rpc` and `--private-key` arguments for correctness

### DIFF
--- a/attestation_tool.py
+++ b/attestation_tool.py
@@ -1,0 +1,11 @@
+from urllib.parse import urlparse
+
+# RPC validation
+if not urlparse(args.rpc).scheme:
+    print("❌ Invalid RPC URL format.", file=sys.stderr)
+    sys.exit(2)
+
+# Private key validation
+if args.sign and (len(pk) != 64 or not all(c in "0123456789abcdef" for c in pk.lower())):
+    print("❌ Invalid PRIVATE_KEY format. Should be 64 hexadecimal characters.", file=sys.stderr)
+    sys.exit(2)


### PR DESCRIPTION
## Summary

The script currently does not perform validation on the `--rpc` argument (URL) or `--private-key`. If the RPC URL or private key is invalid, the script may fail with unclear errors.

## Proposed Changes

- Add validation to check if `--rpc` is a valid URL (using `urllib` or `Web3`).
- Ensure the `--private-key` is in the correct hexadecimal format, and show an error message if it is invalid.

## Motivation

- Helps users avoid misconfiguration errors.  
- Improves error handling and user feedback.